### PR TITLE
PR-6 | Switch to YAML for application configuration

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.application.name=journalApplication
-
-spring.config.import=file:dev.env.properties
-
-spring.data.mongodb.uri=${MONGODB_CONNECTION_STRING}
-spring.data.mongodb.database=${MONGODB_DATABASE_NAME}
-spring.data.mongodb.auto-index-creation=true
-
-spring.main.allow-circular-references=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name: journalApplication
+
+  main:
+    allow-circular-references: true
+
+  config:
+    import: file:dev.env.properties
+
+  data:
+    mongodb:
+      uri: ${MONGODB_CONNECTION_STRING}
+      database: ${MONGODB_DATABASE_NAME}
+      auto-index-creation: true


### PR DESCRIPTION
Replaced `application.properties` with `application.yml` for improved readability and hierarchical configuration benefits. Maintained all existing configuration settings without changes.